### PR TITLE
 [improvement][ai][general] Add SUTime rules and handle ordinals better

### DIFF
--- a/models/edu/stanford/nlp/models/sutime/english.holidays.sutime.txt
+++ b/models/edu/stanford/nlp/models/sutime/english.holidays.sutime.txt
@@ -2,12 +2,12 @@
   ENV.defaults["ruleType"] = "tokens"
 
   $POSS = "( /'s/ | /'/ /s/ )"
-  { (/new/ (/year|years/) $POSS? /eve/ ) => IsoDate(NIL, 12, 31) }
-  { (/new/ (/year|years/) $POSS? /day/? ) => IsoDate(NIL, 1, 1) }
+  { (/new/ (/years?/) $POSS? /eve/ ) => IsoDate(NIL, 12, 31) }
+  { (/new/ (/years?/) $POSS? /day/? ) => IsoDate(NIL, 1, 1) }
   { (/inauguration/ /day/ ) => IsoDate(NIL, 1, 20) }
   { (/groundhog/ /day/ ) => IsoDate(NIL, 2, 2) }
-  { (/st.?|saint/? (/valentine|valentines/) $POSS? /day/ ) => IsoDate(NIL, 2, 14) }
-  { (/st.?|saint/ (/patrick|patricks|patty|pattys/) $POSS? /day/ ) => IsoDate(NIL, 3, 17) }
+  { (/st.?|saint/? (/valentines?/) $POSS? /day/ ) => IsoDate(NIL, 2, 14) }
+  { (/st.?|saint/ (/patricks?|pattys?/) $POSS? /day/ ) => IsoDate(NIL, 3, 17) }
   { (/april/ /fools/ /day/? ) => IsoDate(NIL, 4, 1) }
   { (/cinco/ /de/ /mayo/ ) => IsoDate(NIL, 5, 5) }
   { (/independence/ /day/ ) => IsoDate(NIL, 7, 4) }

--- a/models/edu/stanford/nlp/models/sutime/english.holidays.sutime.txt
+++ b/models/edu/stanford/nlp/models/sutime/english.holidays.sutime.txt
@@ -2,14 +2,15 @@
   ENV.defaults["ruleType"] = "tokens"
 
   $POSS = "( /'s/ | /'/ /s/ )"
-  { (/new/ /year/ $POSS? /eve/ ) => IsoDate(NIL, 12, 31) }
-  { (/new/ /year/ $POSS? /day/? ) => IsoDate(NIL, 1, 1) }
+  { (/new/ (/year|years/) $POSS? /eve/ ) => IsoDate(NIL, 12, 31) }
+  { (/new/ (/year|years/) $POSS? /day/? ) => IsoDate(NIL, 1, 1) }
   { (/inauguration/ /day/ ) => IsoDate(NIL, 1, 20) }
   { (/groundhog/ /day/ ) => IsoDate(NIL, 2, 2) }
-  { (/st.?|saint/? /valentine/ $POSS? /day/ ) => IsoDate(NIL, 2, 14) }
-  { (/st.?|saint/ /patrick/ $POSS? /day/ ) => IsoDate(NIL, 3, 17) }
+  { (/st.?|saint/? (/valentine|valentines/) $POSS? /day/ ) => IsoDate(NIL, 2, 14) }
+  { (/st.?|saint/ (/patrick|patricks|patty|pattys/) $POSS? /day/ ) => IsoDate(NIL, 3, 17) }
   { (/april/ /fools/ /day/? ) => IsoDate(NIL, 4, 1) }
   { (/cinco/ /de/ /mayo/ ) => IsoDate(NIL, 5, 5) }
+  { (/independence/ /day/ ) => IsoDate(NIL, 7, 4) }
   { (/halloween/ ) => IsoDate(NIL, 10, 31) }
   { (/x-?mas|christmas/ /eve/ ) => IsoDate(NIL, 12, 24) }
   { (/x-?mas|christmas/ /day/? ) => IsoDate(NIL, 12, 25) }

--- a/models/edu/stanford/nlp/models/sutime/english.sutime.txt
+++ b/models/edu/stanford/nlp/models/sutime/english.sutime.txt
@@ -14,7 +14,7 @@
 
   $INT_TIMES = ( $INT /times/ | once | twice | thrice );
   $REL_MOD = ( /the/? /next|following|last|previous/ | /this/ /coming|past/? | /the/ /coming|past/ );
-  $FREQ_MOD = ( /each/ | /every/ $NUM_ORD | /every/ /other|alternate|alternating/? | /alternate|alternating/ );
+  $FREQ_MOD = ( /each/ | /per/ | /every/ $NUM_ORD | /every/ /other|alternate|alternating/? | /alternate|alternating/ );
   $EARLY_LATE_MOD = ( /late|early|mid-?/ | /the/? /beginning|start|dawn|middle|end/ /of/ | /late|early/ /in|on/ );
   $APPROX_MOD = ( /about|around|some|exactly|precisely/ );
   $YEAR = ( /[012]\d\d\d/ | /'\d\d/ | /'/ /\d\d/ | /\w+teen|twenty/ [ { numcompvalue<100 } & { numcompvalue>0 } & $INT ] );
@@ -176,7 +176,7 @@
 	action: Tag($0, "Modifier", "MID") }
 
   # Frequency modifiers
-  { pattern: ( /each/ | /every/ ),
+  { pattern: ( /each/ | /every/ | /per/ ),
     action: ( Tag($0, "PTS.quant", $0), Tag($0, "PTS.multiple", 1 ) ) }
   { pattern: ( /every/ ($NUM_ORD|$INT) ),
     action: ( Tag($0, "PTS.quant", $0), Tag($0, "PTS.multiple", $1[0].numcompvalue ) ) }
@@ -593,6 +593,12 @@
     }
   }
 
+  # i.e. the month of may
+  { name: "composite-date-expression-0",
+  priority: 1,
+  pattern: ( /the/? /month/ /of/ (?$month [ { temporal::MONTH } ]) ),
+  result: IsoDate( NIL, $month[0].temporal.value.month, NIL ) }
+
   { name: "composite-date-expression-1a",
 	priority: 1,
 	pattern: ( (/every/ $NUM_ORD) (?$month [ { temporal::MONTH }]) ),
@@ -977,4 +983,3 @@
 
   # Reject anything that is just a timezone
   {  pattern: ( [ {{ tags["TIMEZONE"] }} ] ), over: NIL  }
-

--- a/models/edu/stanford/nlp/models/sutime/english.sutime.txt
+++ b/models/edu/stanford/nlp/models/sutime/english.sutime.txt
@@ -14,8 +14,8 @@
 
   $INT_TIMES = ( $INT /times/ | once | twice | thrice );
   $REL_MOD = ( /the/? /next|following|last|previous/ | /this/ /coming|past/? | /the/ /coming|past/ );
-  $FREQ_MOD = ( /each|per/ | /every|per/ $NUM_ORD | /every|per/ /other|alternate|alternating/? | /alternate|alternating/ );
-  $EARLY_LATE_MOD = ( /late|early|mid-?/ | /the/? /beginning|start|dawn|middle|end/ /of/ );
+  $FREQ_MOD = ( /each/ | /every/ $NUM_ORD | /every/ /other|alternate|alternating/? | /alternate|alternating/ );
+  $EARLY_LATE_MOD = ( /late|early|mid-?/ | /the/? /beginning|start|dawn|middle|end/ /of/ | /late|early/ /in|on/ );
   $APPROX_MOD = ( /about|around|some|exactly|precisely/ );
   $YEAR = ( /[012]\d\d\d/ | /'\d\d/ | /'/ /\d\d/ | /\w+teen|twenty/ [ { numcompvalue<100 } & { numcompvalue>0 } & $INT ] );
   $POSSIBLE_YEAR = ( $YEAR /a\.?d\.?|b\.?c\.?/? | $INT /a\.?d\.?|b\.?c\.?/ | $INT1000TO3000 );
@@ -250,6 +250,7 @@
   { (/suppertimes?/) => SUPPERTIME }
   { (/daylights?|days?|daytimes?/) => DAYTIME }
   { (/nighttimes?|nights?|overnights?/) => NIGHT }
+  { (/workday|work day|business hours/) => WORKDAY }
 
   # Seasons
   { (/summers?/) => SUMMER }
@@ -308,9 +309,12 @@
   { (/dec\.?/) => DECEMBER }
 
   { ruleType: "filter",
-	over: NIL,
-    pattern: ( [ { temporal::IS_TIMEX_DATE } & {{ tokens[0].tag =~ /NN.*S/ }} ] ),
-    result: MakePeriodicTemporalSet($0[0].temporal.value)
+    over: NIL,
+    // We added the end in "s" condition to avoid tagging mistakes (as with 1879) leading to non-plurals being SET
+    pattern: ( [ { temporal::IS_TIMEX_DATE } & {{ tokens[0].tag =~ /NN.*S/ }} & {{ tokens[0].word =~ /.+s/ }} ] ),
+    result: MakePeriodicTemporalSet($0[0].temporal.value),
+    // Set to TRUE to turn anything that is labeled a date but marked as plural to be a set
+    active: FALSE
   }
 
   ########################################################################################################################
@@ -888,26 +892,41 @@
 	           ( [ $hasTemporal & !{ temporal::IS_TIMEX_SET } ] ) ),
     result: $0[-1].temporal.value
   }
-
   { name: "temporal-composite-7a",
     pattern: ( /every/ ( [ $hasTemporal & !{ temporal::IS_TIMEX_SET } ] ) ),
-	result: MakePeriodicTemporalSet($1[0].temporal, "every", 1 )
+	  result: MakePeriodicTemporalSet($1[0].temporal, "every", 1 )
   }
-
   { name: "temporal-composite-7b",
-#    pattern: ( ( $FREQ_MOD ) ( [ $hasTemporal & !{ temporal::IS_TIMEX_SET } ] ) ),
+#   pattern: ( ( $FREQ_MOD ) ( [ $hasTemporal & !{ temporal::IS_TIMEX_SET } ] ) ),
     pattern: ( ( $FREQ_MOD ) ( [ $hasTemporal ] ) ),
-	result: MakePeriodicTemporalSet($2[0].temporal, GetTag($1[0], "PTS.quant"), GetTag($1[0], "PTS.multiple") )
+	  result: MakePeriodicTemporalSet($2[0].temporal, GetTag($1[0], "PTS.quant"), GetTag($1[0], "PTS.multiple") )
   }
-
-  { name: "temporal-composite-8:ranges",
-	active: options."markTimeRanges",
-    pattern: ( /from|between/? ( [ { temporal::IS_TIMEX_TIME } | { temporal::IS_TIMEX_DATE } ] ) /to|and|through|-/ ( [ { temporal::IS_TIMEX_TIME } |   {   temporal::IS_TIMEX_DATE } ] ) ),
-	result: TimeRange( $1[0].temporal.value, $2[0].temporal.value ) }
-
+  { name: "temporal-composite-8a",
+    active: options."markTimeRanges",
+    pattern: ( /from|between/ /the/? ($INTORD) /to|and|through|-/ ( [ { temporal::IS_TIMEX_TIME } | { temporal::IS_TIMEX_DATE } ] ) ),
+	  result: TimeRange( $1[0].numcompvalue, $2[0].temporal.value.month, $2[0].temporal.value )
+  }
+  { name: "temporal-composite-8b",
+	  active: options."markTimeRanges",
+    pattern: ( /from|between/ ( [ { temporal::IS_TIMEX_TIME } | { temporal::IS_TIMEX_DATE } ] ) /to|and|through|-/ ( [ { temporal::IS_TIMEX_TIME } |   {   temporal::IS_TIMEX_DATE } ] ) ),
+	  result: TimeRange( $1[0].temporal.value, $2[0].temporal.value )
+  }
   { name: "temporal-composite-9",
-	pattern: ( [{ temporal::IS_TIMEX_TIME }] (?: /sharp/|/exactly/|/precisely/|/on/ /the/ /dot/) ),
-    result: $0[0].temporal.value }
+	  pattern: ( [{ temporal::IS_TIMEX_TIME }] (?: /sharp/|/exactly/|/precisely/|/on/ /the/ /dot/) ),
+    result: $0[0].temporal.value
+  }
+  { name: "temporal-composite-10",
+	  pattern: ( /since/ ( [ { temporal::IS_TIMEX_DATE } ] ) ),
+    result: TimeRange( $1[0].temporal.value, NIL, 0, 0 )
+  }
+  { name: "temporal-composite-11",
+	  pattern: ( ( /after/ | /later/ /than/ ) /the/? ( [ { temporal::IS_TIMEX_DATE } ] ) ),
+    result: TimeRange( $2[0].temporal.value, NIL, 1, 0 )
+  }
+  { name: "temporal-composite-12",
+	  pattern: ( ( /before/ | /prior/ /to/ | /until/ ) /the/? ( [ { temporal::IS_TIMEX_DATE } ] ) ),
+    result: TimeRange( NIL, $2[0].temporal.value, 0, 1 )
+  }
 
   ########################################################################################################################
 
@@ -915,10 +934,10 @@
   ENV.defaults["ruleType"] = "tokens"
 
   # Vague times
-  { ( /the/ /past/ | /newly/ | /not/ /long/ /ago/ | /these/ /days/) => TIME_PAST }
+  { ( /the/ /past/ | /recently/ ) => TIME_PAST }
   { pattern: ( /at/ /the/ (/time/) ), matchedExpressionGroup: 1, result: TIME_PAST }
-  { ( /once|medieval|previously/ ) => TIME_PAST }
-  { ( /present|presently|current|currently/ | /right/? /now/ ) => TIME_PRESENT }
+  { ( /past|once|medieval|previously/ ) => TIME_PAST }
+  { ( /present|current|currently/ | /right/? /now/ ) => TIME_PRESENT }
   { (  /the/? /near/? /future/ ) => TIME_FUTURE }
 
   # Final rules to determine how to resolve date
@@ -930,7 +949,7 @@
   {  pattern: ( [ { tag:/VBD/ } | /have/ ] []{0,2} [ $hasTemporal ] ),
      action: VTag( $0[-1].temporal.value, "resolveTo", RESOLVE_TO_PAST )
   }
-  {  pattern: ( [ $hasTemporal ] []{0,2} [ { tag:/VBD/ } | /have/ ] ),
+  {  pattern: ( [ $hasTemporal ] []{0,2} [ { tag:/VBD/ } | /after/ | /since/ ] ),
      action: VTag( $0[0].temporal.value, "resolveTo", RESOLVE_TO_PAST )
   }
   {  pattern: ( (/would/ | /could/ | /should/ | /will/ | /going/ /to/ | /'/ /ll/ | /'ll/ )

--- a/models/edu/stanford/nlp/models/sutime/english.sutime.txt
+++ b/models/edu/stanford/nlp/models/sutime/english.sutime.txt
@@ -14,7 +14,7 @@
 
   $INT_TIMES = ( $INT /times/ | once | twice | thrice );
   $REL_MOD = ( /the/? /next|following|last|previous/ | /this/ /coming|past/? | /the/ /coming|past/ );
-  $FREQ_MOD = ( /each/ | /per/ | /every/ $NUM_ORD | /every/ /other|alternate|alternating/? | /alternate|alternating/ );
+  $FREQ_MOD = ( /each|every|per/ $NUM_ORD | /each|every|per/ /other|alternate|alternating/? | /alternate|alternating/ );
   $EARLY_LATE_MOD = ( /late|early|mid-?/ | /the/? /beginning|start|dawn|middle|end/ /of/ | /late|early/ /in|on/ );
   $APPROX_MOD = ( /about|around|some|exactly|precisely/ );
   $YEAR = ( /[012]\d\d\d/ | /'\d\d/ | /'/ /\d\d/ | /\w+teen|twenty/ [ { numcompvalue<100 } & { numcompvalue>0 } & $INT ] );
@@ -176,11 +176,11 @@
 	action: Tag($0, "Modifier", "MID") }
 
   # Frequency modifiers
-  { pattern: ( /each/ | /every/ | /per/ ),
+  { pattern: ( /each|every|per/ ),
     action: ( Tag($0, "PTS.quant", $0), Tag($0, "PTS.multiple", 1 ) ) }
-  { pattern: ( /every/ ($NUM_ORD|$INT) ),
+  { pattern: ( /each|every|per/ ($NUM_ORD|$INT) ),
     action: ( Tag($0, "PTS.quant", $0), Tag($0, "PTS.multiple", $1[0].numcompvalue ) ) }
-  { pattern: ( /every/ /other|alternate|alternating/ | /alternate|alternating/ ),
+  { pattern: ( /each|every|per/ /other|alternate|alternating/ | /alternate|alternating/ ),
     action: ( Tag($0, "PTS.quant", $0), Tag($0, "PTS.multiple", 2 ) ) }
 
   # Approximate modifiers
@@ -899,36 +899,57 @@
     result: $0[-1].temporal.value
   }
   { name: "temporal-composite-7a",
-    pattern: ( /every/ ( [ $hasTemporal & !{ temporal::IS_TIMEX_SET } ] ) ),
+    pattern: ( /every|each|per/ ( [ $hasTemporal & !{ temporal::IS_TIMEX_SET } ] ) ),
 	  result: MakePeriodicTemporalSet($1[0].temporal, "every", 1 )
   }
   { name: "temporal-composite-7b",
-#   pattern: ( ( $FREQ_MOD ) ( [ $hasTemporal & !{ temporal::IS_TIMEX_SET } ] ) ),
     pattern: ( ( $FREQ_MOD ) ( [ $hasTemporal ] ) ),
 	  result: MakePeriodicTemporalSet($2[0].temporal, GetTag($1[0], "PTS.quant"), GetTag($1[0], "PTS.multiple") )
   }
+
+  # handles time ranges where the first time is only an ordinal.
+  # e.g. between the first and third of june
+  # e.g. From the 10th through the 12th of December.
   { name: "temporal-composite-8a",
     active: options."markTimeRanges",
     pattern: ( /from|between/ /the/? ($INTORD) /to|and|through|-/ ( [ { temporal::IS_TIMEX_TIME } | { temporal::IS_TIMEX_DATE } ] ) ),
 	  result: TimeRange( $1[0].numcompvalue, $2[0].temporal.value.month, $2[0].temporal.value )
   }
+
+  # handles time ranges where both values are times/dates
+  # e.g. between the first of june and third of june
+  # e.g. From the 10th of December through the 12th of December.
   { name: "temporal-composite-8b",
 	  active: options."markTimeRanges",
     pattern: ( /from|between/ ( [ { temporal::IS_TIMEX_TIME } | { temporal::IS_TIMEX_DATE } ] ) /to|and|through|-/ ( [ { temporal::IS_TIMEX_TIME } |   {   temporal::IS_TIMEX_DATE } ] ) ),
 	  result: TimeRange( $1[0].temporal.value, $2[0].temporal.value )
   }
+
   { name: "temporal-composite-9",
 	  pattern: ( [{ temporal::IS_TIMEX_TIME }] (?: /sharp/|/exactly/|/precisely/|/on/ /the/ /dot/) ),
     result: $0[0].temporal.value
   }
+
+  # handles open-ended ranges inclusive of the start date
+  # e.g. since may
+  # e.g. since June 5th, 1918
   { name: "temporal-composite-10",
 	  pattern: ( /since/ ( [ { temporal::IS_TIMEX_DATE } ] ) ),
     result: TimeRange( $1[0].temporal.value, NIL, 0, 0 )
   }
+
+  # handles open-ended ranges exclusive of the start date
+  # e.g. after may
+  # e.g. later than June 5th, 1918
   { name: "temporal-composite-11",
 	  pattern: ( ( /after/ | /later/ /than/ ) /the/? ( [ { temporal::IS_TIMEX_DATE } ] ) ),
     result: TimeRange( $2[0].temporal.value, NIL, 1, 0 )
   }
+
+  # handles open-ended ranges exclusive of the end date
+  # e.g. before the sixth of may
+  # e.g. prior to June 5th, 1918
+  # e.g. until sunday
   { name: "temporal-composite-12",
 	  pattern: ( ( /before/ | /prior/ /to/ | /until/ ) /the/? ( [ { temporal::IS_TIMEX_DATE } ] ) ),
     result: TimeRange( NIL, $2[0].temporal.value, 0, 1 )
@@ -940,10 +961,10 @@
   ENV.defaults["ruleType"] = "tokens"
 
   # Vague times
-  { ( /the/ /past/ | /recently/ ) => TIME_PAST }
+  { ( /the/ /past/ | /recently/ | /newly/ | /not/ /long/ /ago/ | /these/ /days/) => TIME_PAST }
   { pattern: ( /at/ /the/ (/time/) ), matchedExpressionGroup: 1, result: TIME_PAST }
   { ( /past|once|medieval|previously/ ) => TIME_PAST }
-  { ( /present|current|currently/ | /right/? /now/ ) => TIME_PRESENT }
+  { ( /present|presently|current|currently/ | /right/? /now/ ) => TIME_PRESENT }
   { (  /the/? /near/? /future/ ) => TIME_FUTURE }
 
   # Final rules to determine how to resolve date
@@ -955,7 +976,7 @@
   {  pattern: ( [ { tag:/VBD/ } | /have/ ] []{0,2} [ $hasTemporal ] ),
      action: VTag( $0[-1].temporal.value, "resolveTo", RESOLVE_TO_PAST )
   }
-  {  pattern: ( [ $hasTemporal ] []{0,2} [ { tag:/VBD/ } | /after/ | /since/ ] ),
+  {  pattern: ( [ $hasTemporal ] []{0,2} [ { tag:/VBD/ } | /after/ | /since/ | /have/ ] ),
      action: VTag( $0[0].temporal.value, "resolveTo", RESOLVE_TO_PAST )
   }
   {  pattern: ( (/would/ | /could/ | /should/ | /will/ | /going/ /to/ | /'/ /ll/ | /'ll/ )

--- a/src/edu/stanford/nlp/time/SUTime.java
+++ b/src/edu/stanford/nlp/time/SUTime.java
@@ -4499,6 +4499,34 @@ public class SUTime  {
       this.duration = duration;
     }
 
+    public Range(Number beginDay, Number beginMonth, Time end) {
+      this.begin = (Time) new IsoDate(null, beginMonth, beginDay);
+      this.end = end;
+      this.duration = Time.difference(this.begin, this.end);
+    }
+
+    public Range(Time begin, Time end, int beginExclusive, int endExclusive) {
+      if (beginExclusive == 1) {
+        begin = shiftRight(begin);
+      }
+      if (endExclusive == 1) {
+        end = shiftLeft(end);
+      }
+      this.begin = begin;
+      this.end = end;
+      this.duration = DURATION_UNKNOWN;
+    }
+
+    private Time shiftLeft(Time time) {
+      Duration duration = time.getGranularity();
+      return time.subtract(duration);
+    }
+
+    private Time shiftRight(Time time) {
+      Duration duration = time.getGranularity();
+      return time.add(duration);
+    }
+
     @Override
     public Range setTimeZone(DateTimeZone tz) {
       return new Range(this, (Time) Temporal.setTimeZone(begin, tz), (Time) Temporal.setTimeZone(end, tz), duration);


### PR DESCRIPTION
This change adds some SUTime rules to handle more date variations and fixes issues related to ordinal parsing.
*  **[feature-added]** Added SUTime rules to support utterances with since/after/before (e.g. "before December" or "since July"). These are treated as open-ended ranges that only return either a startDate or an endDate.
*  **[issue-fixed]** Fixed an issue where holidays that end with an 'S' (e.g. christmas and possessives without an apostrophe like new years day, saint patricks day, valentines day).
*  **[issue-fixed]** Fixed an issue with utterances that involve a duration between two ordinals (e.g. between the first and fourth of may) and added support for such utterances with a composite rule.
*  **[feature-added]** Added SUTime rule to support utterances like "the month of may" directly (i.e.  without an INTERSECT)