### PR TITLE
[improvement][ai][general] Add holiday and time range grammar

### DIFF
--- a/models/edu/stanford/nlp/models/sutime/english.holidays.sutime.txt
+++ b/models/edu/stanford/nlp/models/sutime/english.holidays.sutime.txt
@@ -2,18 +2,20 @@
   ENV.defaults["ruleType"] = "tokens"
 
   $POSS = "( /'s/ | /'/ /s/ )"
-  { (/new/ (/years?/) $POSS? /eve/ ) => IsoDate(NIL, 12, 31) }
+  { (/new/ (/years?/) $POSS? /eve/ | /nye/) => IsoDate(NIL, 12, 31) }
   { (/new/ (/years?/) $POSS? /day/? ) => IsoDate(NIL, 1, 1) }
   { (/inauguration/ /day/ ) => IsoDate(NIL, 1, 20) }
   { (/groundhog/ /day/ ) => IsoDate(NIL, 2, 2) }
-  { (/st.?|saint/? (/valentines?/) $POSS? /day/ ) => IsoDate(NIL, 2, 14) }
-  { (/st.?|saint/ (/patricks?|pattys?/) $POSS? /day/ ) => IsoDate(NIL, 3, 17) }
+  { (/st.?|saint/? (/valentines?|vals?/) $POSS? /day/? ) => IsoDate(NIL, 2, 14) }
+  { (/st.?|saint/? (/patricks?|pa(tt|dd)ys?/) $POSS? /day/ ) => IsoDate(NIL, 3, 17) }
+  { (/st.?|saint/? /andrews?/ $POSS? /day/ ) => IsoDate(NIL, 11, 30) }
   { (/april/ /fools/ /day/? ) => IsoDate(NIL, 4, 1) }
   { (/cinco/ /de/ /mayo/ ) => IsoDate(NIL, 5, 5) }
   { (/independence/ /day/ ) => IsoDate(NIL, 7, 4) }
   { (/halloween/ ) => IsoDate(NIL, 10, 31) }
-  { (/x-?mas|christmas/ /eve/ ) => IsoDate(NIL, 12, 24) }
-  { (/x-?mas|christmas/ /day/? ) => IsoDate(NIL, 12, 25) }
+  { ((/x/ /`/ /mas/|/x-?mas/|/christmas/) /eve/ ) => IsoDate(NIL, 12, 24) }
+  { ((/x/ /`/ /mas/|/x-?mas/|/christmas/) /day/? ) => IsoDate(NIL, 12, 25) }
+  { (/boxing/ /day/ ) => IsoDate(NIL, 12, 26) }
 
 
   { (/martin/ /luther/ /king/ /day/ | /mlk/ /day/) => JH_MARTIN_LUTHER_KING }

--- a/models/edu/stanford/nlp/models/sutime/english.sutime.txt
+++ b/models/edu/stanford/nlp/models/sutime/english.sutime.txt
@@ -12,6 +12,8 @@
   $INT1TO31 = ( [ $INTORD & !{ word:/\+.*/} & { numcompvalue>=1 } & { numcompvalue<=31 } ] );
   $NUM_ORD = ( [ { numcomptype:ORDINAL } ] );
 
+  $THROUGH = ( /to|through|thru|till|until|til|-/ );
+
   $INT_TIMES = ( $INT /times/ | once | twice | thrice );
   $REL_MOD = ( /the/? /next|following|last|previous/ | /this/ /coming|past/? | /the/ /coming|past/ );
   $FREQ_MOD = ( /each|every|per/ $NUM_ORD | /each|every|per/ /other|alternate|alternating/? | /alternate|alternating/ );
@@ -912,17 +914,53 @@
   # e.g. From the 10th through the 12th of December.
   { name: "temporal-composite-8a",
     active: options."markTimeRanges",
-    pattern: ( /from|between/ /the/? ($INTORD) /to|and|through|-/ ( [ { temporal::IS_TIMEX_TIME } | { temporal::IS_TIMEX_DATE } ] ) ),
-	  result: TimeRange( $1[0].numcompvalue, $2[0].temporal.value.month, $2[0].temporal.value )
+    pattern: ( /from|between|since/ /the/? ($INTORD) ($THROUGH|/and/) ( [ { temporal::IS_TIMEX_TIME } | { temporal::IS_TIMEX_DATE } ] ) ),
+	  result: TimeRange( $1[0].numcompvalue, $3[0].temporal.value.month, $3[0].temporal.value )
+  }
+
+  # handles time ranges where the second time is only an ordinal.
+  # e.g. between the first of june and the third
+  # e.g. From the 10th of December through the 12th.
+  { name: "temporal-composite-8b",
+    active: options."markTimeRanges",
+    pattern: ( /from|between|since/ ( [ { temporal::IS_TIMEX_TIME } | { temporal::IS_TIMEX_DATE } ] ) ($THROUGH|/and/) /the/? ($INTORD) ),
+	  result: TimeRange( $1[0].temporal.value, $1[0].temporal.value.month, $3[0].numcompvalue )
+  }
+
+  # handles time ranges where both values are times/dates without a leading word
+  # e.g. first of june through third of june
+  # e.g. the 10th of December till the 12th of December.
+  { name: "temporal-composite-8c",
+	  active: options."markTimeRanges",
+    pattern: ( ( [ { temporal::IS_TIMEX_TIME } | { temporal::IS_TIMEX_DATE } ] ) $THROUGH ( [ { temporal::IS_TIMEX_TIME } |   {   temporal::IS_TIMEX_DATE } ] ) ),
+	  result: TimeRange( $1[0].temporal.value, $2[0].temporal.value )
   }
 
   # handles time ranges where both values are times/dates
   # e.g. between the first of june and third of june
   # e.g. From the 10th of December through the 12th of December.
-  { name: "temporal-composite-8b",
+  { name: "temporal-composite-8d",
 	  active: options."markTimeRanges",
-    pattern: ( /from|between/ ( [ { temporal::IS_TIMEX_TIME } | { temporal::IS_TIMEX_DATE } ] ) /to|and|through|-/ ( [ { temporal::IS_TIMEX_TIME } |   {   temporal::IS_TIMEX_DATE } ] ) ),
-	  result: TimeRange( $1[0].temporal.value, $2[0].temporal.value )
+    pattern: ( /from|between|since/ ( [ { temporal::IS_TIMEX_TIME } | { temporal::IS_TIMEX_DATE } ] ) ($THROUGH|/and/) ( [ { temporal::IS_TIMEX_TIME } |   {   temporal::IS_TIMEX_DATE } ] ) ),
+	  result: TimeRange( $1[0].temporal.value, $3[0].temporal.value )
+  }
+
+  # handles time ranges where the first time is only a cardinal/ordinal without a leading word
+  # e.g. 1 - 28 Feb
+  # e.g. the 1st to 4th of May
+  { name: "temporal-composite-8e",
+    active: options."markTimeRanges",
+    pattern: ( /the/? ($INTORD) $THROUGH ( [ { temporal::IS_TIMEX_TIME } | { temporal::IS_TIMEX_DATE } ] ) ),
+	  result: TimeRange( $1[0].numcompvalue, $2[0].temporal.value.month, $2[0].temporal.value )
+  }
+
+  # handles time ranges where the second time is only a cardinal/ordinal without a leading word
+  # e.g. june 1st through the 4th
+  # e.g. 12 December to the twentieth.
+  { name: "temporal-composite-8f",
+    active: options."markTimeRanges",
+    pattern: ( ( [ { temporal::IS_TIMEX_TIME } | { temporal::IS_TIMEX_DATE } ] ) $THROUGH /the/? ($INTORD) ),
+	  result: TimeRange( $1[0].temporal.value, $1[0].temporal.value.month, $2[0].numcompvalue )
   }
 
   { name: "temporal-composite-9",

--- a/src/edu/stanford/nlp/time/SUTime.java
+++ b/src/edu/stanford/nlp/time/SUTime.java
@@ -4505,6 +4505,12 @@ public class SUTime  {
       this.duration = Time.difference(this.begin, this.end);
     }
 
+    public Range(Time begin, Number endMonth, Number endDay) {
+      this.begin = begin;
+      this.end = (Time) new IsoDate(null, endMonth, endDay);
+      this.duration = Time.difference(this.begin, this.end);
+    }
+
     public Range(Time begin, Time end, int beginExclusive, int endExclusive) {
       if (beginExclusive == 1) {
         begin = shiftRight(begin);


### PR DESCRIPTION
Added to the SUTime rules in order to support the following date formats:

- Since xx till xx
- 1 - 28 Feb
- 1st - 28th February
- Feb 1st - 28th
- February 1 - 28
- Valentines
- Vals Day
- Valentine's
- Val's Day
- x'mas
- Boxing day
- NYE
- St paddys day
- Paddys day
- Saint Paddys day
- St Andrews Day
- Since xx to xx

Testing has been added in an MR on GitLab for each of these cases.